### PR TITLE
Fix bed coordinates reference for 8-screen mode

### DIFF
--- a/bed_coords.py
+++ b/bed_coords.py
@@ -1,4 +1,4 @@
-BED_COORDS = {
+BED_COORDS_8 = {
     2: {
         "BP_COMBINED_COORD": (457, 441, 155, 38),
         "CVP_COORDS": (454, 477, 35, 33),
@@ -111,3 +111,6 @@ BED_COORDS = {
         }
     }
 }
+
+# Backward compatibility alias
+BED_COORDS = BED_COORDS_8

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -40,7 +40,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover
     Image = None
 
-from bed_coords import BED_COORDS as BED_COORDS_8
+from bed_coords import BED_COORDS_8
 from bed_coords_4 import BED_COORDS_4
 
 cvp_model = None
@@ -570,7 +570,8 @@ if __name__ == "__main__":
     args = parse_args()
     config = load_config(args.config)
 
-    print(BED_COORDS.keys())
+    # Display available 8-screen bed coordinate keys
+    print(BED_COORDS_8.keys())
 
     cvp_model_path = resolve_path(
         args.cvp_model,


### PR DESCRIPTION
## Summary
- Rename 8-screen bed coordinate dictionary to `BED_COORDS_8` with backward-compatible alias
- Import `BED_COORDS_8` directly in `vital_reader.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba353a45f4832b9287a59d2cbc3321