### PR TITLE
Avoid persisting furosemide IV doses in CSV

### DIFF
--- a/tests/test_furosemide_not_persistent.py
+++ b/tests/test_furosemide_not_persistent.py
@@ -1,0 +1,18 @@
+import csv
+from datetime import datetime
+
+import drug_panel
+from vital_reader import save_vitals_to_csv
+
+
+def test_save_vitals_does_not_carry_forward_furosemide(tmp_path):
+    csv_path = tmp_path / "vitals.csv"
+    panel = drug_panel.DrugPanel.__new__(drug_panel.DrugPanel)
+    panel.csv_path = csv_path
+    ts = datetime(2023, 1, 1, 0, 0)
+    panel._append_to_csv(ts, {"furosemide_mg": 5})
+    save_vitals_to_csv({"SBP": 120}, csv_path)
+    with open(csv_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert rows[-1]["furosemide_mg"] == ""

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -492,6 +492,11 @@ ALL_COLUMNS = [
     "Ca", "Glu", "Lac", "tBil", "HCO3", "BE", "Alb"
 ]
 
+# Columns that represent one-time events and should not be carried forward when
+# appending new vital rows. Currently only the IV bolus dose of furosemide is
+# treated as non-persistent so that it is logged only at the time of entry.
+NON_PERSISTENT_COLUMNS = {"furosemide_mg"}
+
 def save_vitals_to_csv(vitals_dict, csv_path):
     """Append ``vitals_dict`` to ``csv_path`` while preserving extra columns.
 
@@ -526,7 +531,11 @@ def save_vitals_to_csv(vitals_dict, csv_path):
             # carry forward the most recent values so that the latest row always
             # represents the current state.
             extra_cols = [
-                c for c in fieldnames if c not in ["timestamp"] + ALL_COLUMNS and c not in row
+                c
+                for c in fieldnames
+                if c not in ["timestamp"] + ALL_COLUMNS
+                and c not in row
+                and c not in NON_PERSISTENT_COLUMNS
             ]
             if rows and extra_cols:
                 last = rows[-1]


### PR DESCRIPTION
## Summary
- do not carry over one-time furosemide IV doses when appending vitals
- add regression test to ensure furosemide bolus doesn't persist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba82f20b94832bac299642b24cd078