### PR TITLE
Trigger drain panel message only with sufficient drainage

### DIFF
--- a/tests/test_bleed_rule_tree.py
+++ b/tests/test_bleed_rule_tree.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+pd_stub = types.SimpleNamespace(isna=lambda x: x != x)
+sys.modules.setdefault("pandas", pd_stub)
+
+from vitals.bleed_logic import evaluate_bleed
+import main_surgery as ms
+
+
+def test_tree_bleed_rule_triggers_only_with_drain():
+    pytest.importorskip("yaml")
+    tree_df = ms.load_tree("tree.yaml")
+
+    vitals = {"drain_ml": 20}
+    ids = [r["id"] for r in evaluate_bleed(vitals, tree_df, phase="r")]
+    assert "BLEED" in ids
+
+    # Even if the furosemide check is answered "Y", BLEED should not fire
+    # without sufficient drainage volume.
+    vitals = {"drain_ml": 5, "Y": True}
+    ids = [r["id"] for r in evaluate_bleed(vitals, tree_df, phase="r")]
+    assert "BLEED" not in ids

--- a/tree.yaml
+++ b/tree.yaml
@@ -558,8 +558,8 @@ rules:
   actions:
   - NEXT:なし
 - id: BLEED
-  when: 'True'
-  message: ドレーンパネルを入力してください
+  when: vitals.get("drain_ml", 0) >= 10
+  message: ドレーンに10mL以上の入力がありました。必要に応じてドレーンパネルを開いてください。
   severity: info
   tags:
   - r


### PR DESCRIPTION
## Summary
- recommend opening drain panel only when drainage is at least 10 mL
- add regression test to ensure furosemide check alone does not trigger BLEED

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba83d874dc832ba5f71785b255f183