### PR TITLE
Ensure rule files load from script directory

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -379,8 +379,10 @@ def main_loop(
     for k, v in thresholds.items():
         print(f"{k}: {v}")
 
-    tree_df = load_tree("tree.yaml")
-    bpup_tree_df = load_tree("bpup_tree.yaml")
+    # Load rule trees relative to this script so execution works regardless of
+    # the current working directory.
+    tree_df = load_tree(Path(__file__).with_name("tree.yaml"))
+    bpup_tree_df = load_tree(Path(__file__).with_name("bpup_tree.yaml"))
     last_timestamp = None
     last_instruction_time: dict[str, float] = {}
     vitals_memory = {


### PR DESCRIPTION
## Summary
- Load tree.yaml and bpup_tree.yaml relative to main_surgery.py so rules load regardless of the current working directory

## Testing
- `pytest`
- `pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba90ebe38c832b8eef7f4c018332ef